### PR TITLE
add threshold to automouse

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -159,6 +159,14 @@ config PMW3610_AUTOMOUSE_TIMEOUT_MS
   int "Amount of milliseconds the mouse layer will be active after using the trackball"
   default 400
 
+config PMW3610_MOVEMENT_THRESHOLD
+    int "Movement threshold for automatic mouse layer activation"
+    default 5
+    help
+        The threshold for trackball movement that triggers the automatic mouse layer.
+        A higher value means more movement is required to activate the mouse layer.
+        This helps prevent accidental activation during typing.
+
 module = PMW3610
 module-str = PMW3610
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -612,12 +612,16 @@ static int pmw3610_report_data(const struct device *dev) {
 
     data->curr_mode = input_mode;
 
+    int16_t x;
+    int16_t y;
+
 #if AUTOMOUSE_LAYER > 0
     if (input_mode == MOVE &&
-            (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER)
-    ) {
-        activate_automouse_layer();
-    }
+        (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER) &&
+        (abs(x) + abs(y) > CONFIG_PMW3610_MOVEMENT_THRESHOLD)
+) {
+    activate_automouse_layer();
+}
 #endif
 
     int err = motion_burst_read(dev, buf, sizeof(buf));
@@ -629,9 +633,6 @@ static int pmw3610_report_data(const struct device *dev) {
         TOINT16((buf[PMW3610_X_L_POS] + ((buf[PMW3610_XY_H_POS] & 0xF0) << 4)), 12) / dividor;
     int16_t raw_y =
         TOINT16((buf[PMW3610_Y_L_POS] + ((buf[PMW3610_XY_H_POS] & 0x0F) << 8)), 12) / dividor;
-
-    int16_t x;
-    int16_t y;
 
     if (IS_ENABLED(CONFIG_PMW3610_ORIENTATION_0)) {
         x = -raw_x;
@@ -689,6 +690,15 @@ static int pmw3610_report_data(const struct device *dev) {
 
     if (x != 0 || y != 0) {
         if (input_mode != SCROLL) {
+#if AUTOMOUSE_LAYER > 0
+            // トラックボールの動きの大きさを計算
+            int16_t movement_size = abs(x) + abs(y);
+            if (input_mode == MOVE &&
+                (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER) &&
+                movement_size > CONFIG_PMW3610_MOVEMENT_THRESHOLD) {
+                activate_automouse_layer();
+            }
+#endif
             input_report_rel(dev, INPUT_REL_X, x, false, K_FOREVER);
             input_report_rel(dev, INPUT_REL_Y, y, true, K_FOREVER);
         } else {


### PR DESCRIPTION
オートマウスレイヤーの入力閾値をPMW3610_MOVEMENT_THRESHOLDで設定可能にしました。これにより、タイピング中の振動でわずかにトラックボールが動いた場合でも、勝手にオートマウスに切り替わることが防げます。
618行目でxとyを使う必要があったため、ini16_t x, yの定義を615行目に動かしています。