### PR TITLE
トラボの上下左右操作にキー入力を割り当てる機能

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -160,12 +160,12 @@ config PMW3610_AUTOMOUSE_TIMEOUT_MS
   default 400
 
 config PMW3610_MOVEMENT_THRESHOLD
-int "Movement threshold for automatic mouse layer activation"
-default 5
-help
-    The threshold for trackball movement that triggers the automatic mouse layer.
-    A higher value means more movement is required to activate the mouse layer.
-    This helps prevent accidental activation during typing.
+  int "Movement threshold for automatic mouse layer activation"
+  default 5
+  help
+      The threshold for trackball movement that triggers the automatic mouse layer.
+      A higher value means more movement is required to activate the mouse layer.
+      This helps prevent accidental activation during typing.
 
 config PMW3610_BALL_ACTION_TICK
   int "PMW3610's required ticks to trigger a ball action"

--- a/Kconfig
+++ b/Kconfig
@@ -160,18 +160,18 @@ config PMW3610_AUTOMOUSE_TIMEOUT_MS
   default 400
 
 config PMW3610_MOVEMENT_THRESHOLD
-  int "Movement threshold for automatic mouse layer activation"
-  default 5
-  help
-      The threshold for trackball movement that triggers the automatic mouse layer.
-      A higher value means more movement is required to activate the mouse layer.
-      This helps prevent accidental activation during typing.
+    int "Movement threshold for automatic mouse layer activation"
+    default 5
+    help
+        The threshold for trackball movement that triggers the automatic mouse layer.
+        A higher value means more movement is required to activate the mouse layer.
+        This helps prevent accidental activation during typing.
 
 config PMW3610_BALL_ACTION_TICK
-  int "PMW3610's required ticks to trigger a ball action"
-  default 20
-  help
-    Ball action tick value. Higher values require more movement to trigger a ball action.
+    int "PMW3610's required ticks to trigger a ball action"
+    default 20
+    help
+        Ball action tick value. Higher values require more movement to trigger a ball action.
 
 module = PMW3610
 module-str = PMW3610

--- a/Kconfig
+++ b/Kconfig
@@ -160,12 +160,18 @@ config PMW3610_AUTOMOUSE_TIMEOUT_MS
   default 400
 
 config PMW3610_MOVEMENT_THRESHOLD
-    int "Movement threshold for automatic mouse layer activation"
-    default 5
-    help
-        The threshold for trackball movement that triggers the automatic mouse layer.
-        A higher value means more movement is required to activate the mouse layer.
-        This helps prevent accidental activation during typing.
+int "Movement threshold for automatic mouse layer activation"
+default 5
+help
+    The threshold for trackball movement that triggers the automatic mouse layer.
+    A higher value means more movement is required to activate the mouse layer.
+    This helps prevent accidental activation during typing.
+
+config PMW3610_BALL_ACTION_TICK
+  int "PMW3610's required ticks to trigger a ball action"
+  default 20
+  help
+    Ball action tick value. Higher values require more movement to trigger a ball action.
 
 module = PMW3610
 module-str = PMW3610

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Now, update your `board.overlay` adding the necessary bits (update the pins for 
         //
         //     /*   optional: ball action configuration  */
         //     tick = <10>;
-        //     wait-ms = <10>;
-        //     tap-ms = <10>;
+        //     wait-ms = <5>;
+        //     tap-ms = <5>;
         // };
     };
 };

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Now, update your `board.overlay` adding the necessary bits (update the pins for 
         //
         //     /*   optional: ball action configuration  */
         //     tick = <10>;
-        //     wait-ms = <5>;
-        //     tap-ms = <5>;
+        //     // wait-ms = <5>;
+        //     // tap-ms = <5>;
         // };
     };
 };

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ Now, update your `board.overlay` adding the necessary bits (update the pins for 
         // snipe-layers = <1>;
         // scroll-layers = <2 3>;
         // automouse-layer = <4>;
+
+        /*   optional: ball action on specific layers  */
+        // arrows {
+        //     layers = <3>;
+        //     bindings =
+        //         <&kp RIGHT_ARROW>,
+        //         <&kp LEFT_ARROW>,
+        //         <&kp UP_ARROW>,
+        //         <&kp DOWN_ARROW>;
+        //
+        //     /*   optional: ball action configuration  */
+        //     tick = <10>;
+        //     wait-ms = <10>;
+        //     tap-ms = <10>;
+        // };
     };
 };
 

--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -18,14 +18,6 @@ properties:
   automouse-layer:
     type: int
     default: -1
-  tap-ms:
-    type: int
-    description: Time to wait (in milliseconds) between the press and release events on a triggered listener behavior binding.
-    default: 5
-  wait-ms:
-    type: int
-    description: The default time to wait (in milliseconds) before triggering the next listener behavior binding.
-    default: 5
 
 child-binding:
   description: "Keycodes to be sent when the track ball is moved"

--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -36,3 +36,9 @@ child-binding:
     bindings:
       type: phandle-array
       required: true
+    tick:
+      type: int
+    wait-ms:
+      type: int
+    tap-ms:
+      type: int

--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -34,8 +34,8 @@ child-binding:
       description: "Required ticks to trigger a ball action. Higher values require more movement to trigger a ball action. If omitted, CONFIG_PMW3610_BALL_ACTION_TICK will be used."
       type: int
     wait-ms:
-      description: "Time to wait (in milliseconds) before triggering the next behavior binding. If omitted, CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS will be used."
+      description: "Time to wait (in milliseconds) before triggering the next behavior binding. If omitted, it will be set to 0."
       type: int
     tap-ms:
-      description: "Time to wait (in milliseconds) between the press and release events on a triggered behavior binding. If omitted, CONFIG_ZMK_MACRO_DEFAULT_TAP_MS will be used."
+      description: "Time to wait (in milliseconds) between the press and release events on a triggered behavior binding. If omitted, it will be set to 0."
       type: int

--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -20,17 +20,22 @@ properties:
     default: -1
 
 child-binding:
-  description: "Keycodes to be sent when the track ball is moved"
+  description: "Invoke behaviors when the track ball is moved on specific layers"
   properties:
     layers:
+      description: "Layers on which the behavior will be invoked"
       type: array
       required: true
     bindings:
+      description: "Behaviors to be invoked"
       type: phandle-array
       required: true
     tick:
+      description: "Required ticks to trigger a ball action. Higher values require more movement to trigger a ball action. If omitted, CONFIG_PMW3610_BALL_ACTION_TICK will be used."
       type: int
     wait-ms:
+      description: "Time to wait (in milliseconds) before triggering the next behavior binding. If omitted, CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS will be used."
       type: int
     tap-ms:
+      description: "Time to wait (in milliseconds) between the press and release events on a triggered behavior binding. If omitted, CONFIG_ZMK_MACRO_DEFAULT_TAP_MS will be used."
       type: int

--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -1,5 +1,5 @@
 description: |
-  Sensor driver for the pixart PMW3610 mouse sensor 
+  Sensor driver for the pixart PMW3610 mouse sensor
 
 compatible: "pixart,pmw3610"
 
@@ -18,3 +18,21 @@ properties:
   automouse-layer:
     type: int
     default: -1
+  tap-ms:
+    type: int
+    description: Time to wait (in milliseconds) between the press and release events on a triggered listener behavior binding.
+    default: 5
+  wait-ms:
+    type: int
+    description: The default time to wait (in milliseconds) before triggering the next listener behavior binding.
+    default: 5
+
+child-binding:
+  description: "Keycodes to be sent when the track ball is moved"
+  properties:
+    layers:
+      type: array
+      required: true
+    bindings:
+      type: phandle-array
+      required: true

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-enum pixart_input_mode { MOVE = 0, SCROLL, SNIPE };
+enum pixart_input_mode { MOVE = 0, SCROLL, SNIPE, BALL_ACTION };
 
 /* device data structure */
 struct pixart_data {
@@ -25,6 +25,8 @@ struct pixart_data {
     uint32_t curr_cpi;
     int32_t scroll_delta_x;
     int32_t scroll_delta_y;
+    int32_t ball_action_delta_x;
+    int32_t ball_action_delta_y;
 
 #ifdef CONFIG_PMW3610_POLLING_RATE_125_SW
     int64_t last_poll_time;
@@ -50,6 +52,14 @@ struct pixart_data {
     bool sw_smart_flag;
 };
 
+// ball action config data structure
+struct ball_action_cfg {
+    size_t bindings_len;
+    struct zmk_behavior_binding *bindings;
+    uint8_t layers[ZMK_KEYMAP_LAYERS_LEN];
+    size_t layers_len;
+};
+
 // device config data structure
 struct pixart_config {
     struct gpio_dt_spec irq_gpio;
@@ -59,6 +69,10 @@ struct pixart_config {
     int32_t *scroll_layers;
     size_t snipe_layers_len;
     int32_t *snipe_layers;
+    struct ball_action_cfg **ball_actions;
+    size_t ball_actions_len;
+    uint32_t tap_ms;
+    uint32_t wait_ms;
 };
 
 #ifdef __cplusplus

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -58,6 +58,9 @@ struct ball_action_cfg {
     struct zmk_behavior_binding *bindings;
     uint8_t layers[ZMK_KEYMAP_LAYERS_LEN];
     size_t layers_len;
+    uint32_t tick;
+    uint32_t wait_ms;
+    uint32_t tap_ms;
 };
 
 // device config data structure
@@ -71,8 +74,6 @@ struct pixart_config {
     int32_t *snipe_layers;
     struct ball_action_cfg **ball_actions;
     size_t ball_actions_len;
-    uint32_t tap_ms;
-    uint32_t wait_ms;
 };
 
 #ifdef __cplusplus

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -645,8 +645,8 @@ static int pmw3610_report_data(const struct device *dev) {
 
 #if AUTOMOUSE_LAYER > 0
     if (input_mode == MOVE &&
-            (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER) &&
-            (abs(x) + abs(y) > CONFIG_PMW3610_MOVEMENT_THRESHOLD)
+        (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER) &&
+        (abs(x) + abs(y) > CONFIG_PMW3610_MOVEMENT_THRESHOLD)
     ) {
         activate_automouse_layer();
     }

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -575,6 +575,7 @@ int ball_action_idx = -1;
 static enum pixart_input_mode get_input_mode_for_current_layer(const struct device *dev) {
     const struct pixart_config *config = dev->config;
     uint8_t curr_layer = zmk_keymap_highest_layer_active();
+    ball_action_idx = -1;
     for (size_t i = 0; i < config->scroll_layers_len; i++) {
         if (curr_layer == config->scroll_layers[i]) {
             return SCROLL;

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -767,15 +767,15 @@ static int pmw3610_report_data(const struct device *dev) {
 
                         // determine which binding to invoke
                         int idx = -1;
-                        if(abs(data->ball_action_delta_x) > CONFIG_PMW3610_BALL_ACTION_TICK) {
+                        if(abs(data->ball_action_delta_x) > action_cfg.tick) {
                             idx = data->ball_action_delta_x > 0 ? 0 : 1;
-                        } else if(abs(data->ball_action_delta_y) > CONFIG_PMW3610_BALL_ACTION_TICK) {
+                        } else if(abs(data->ball_action_delta_y) > action_cfg.tick) {
                             idx = data->ball_action_delta_y > 0 ? 3 : 2;
                         }
 
                         if(idx != -1) {
-                            zmk_behavior_queue_add(&event, action_cfg.bindings[idx], true, config->tap_ms);
-                            zmk_behavior_queue_add(&event, action_cfg.bindings[idx], false, config->wait_ms);
+                            zmk_behavior_queue_add(&event, action_cfg.bindings[idx], true, action_cfg.tap_ms);
+                            zmk_behavior_queue_add(&event, action_cfg.bindings[idx], false, action_cfg.wait_ms);
 
                             data->ball_action_delta_x = 0;
                             data->ball_action_delta_y = 0;
@@ -902,6 +902,9 @@ static int pmw3610_init(const struct device *dev) {
         .bindings = ball_action_config_##n##_bindings,                                             \
         .layers = DT_PROP(n, layers),                                                              \
         .layers_len = DT_PROP_LEN(n, layers),                                                      \
+        .tick = DT_PROP_OR(n, tick, CONFIG_PMW3610_BALL_ACTION_TICK),                         \
+        .wait_ms = DT_PROP_OR(n, wait_ms, CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS),                            \
+        .tap_ms = DT_PROP_OR(n, tap_ms, CONFIG_ZMK_MACRO_DEFAULT_TAP_MS),                               \
     };
 
 
@@ -937,8 +940,6 @@ DT_INST_FOREACH_CHILD(0, BALL_ACTIONS_INST)
         .snipe_layers_len = DT_PROP_LEN(DT_DRV_INST(n), snipe_layers),                             \
         .ball_actions = ball_actions,                                                              \
         .ball_actions_len = BALL_ACTIONS_LEN,                                                      \
-        .tap_ms = DT_INST_PROP(n, tap_ms),                                                         \
-        .wait_ms = DT_INST_PROP(n, wait_ms),                                                       \
     };                                                                                             \
                                                                                                    \
     DEVICE_DT_INST_DEFINE(n, pmw3610_init, NULL, &data##n, &config##n, POST_KERNEL,                \

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -637,8 +637,8 @@ static int pmw3610_report_data(const struct device *dev) {
 
     data->curr_mode = input_mode;
 
-    int16_t x;
-    int16_t y;
+    int16_t x = 0;
+    int16_t y = 0;
 
 #if AUTOMOUSE_LAYER > 0
     if (input_mode == MOVE &&

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -13,11 +13,21 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/input/input.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/dlist.h>
+#include <drivers/behavior.h>
 #include <zmk/keymap.h>
+#include <zmk/behavior.h>
+#include <zmk/keys.h>
+#include <zmk/behavior_queue.h>
+#include <zmk/event_manager.h>
+#include <zmk/events/position_state_changed.h>
+#include <zmk/events/layer_state_changed.h>
 #include "pmw3610.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pmw3610, CONFIG_INPUT_LOG_LEVEL);
+
 
 //////// Sensor initialization steps definition //////////
 // init is done in non-blocking manner (i.e., async), a //
@@ -574,6 +584,13 @@ static enum pixart_input_mode get_input_mode_for_current_layer(const struct devi
             return SNIPE;
         }
     }
+    for (size_t i = 0; i < config->ball_actions_len; i++) {
+        for (size_t j = 0; j < config->ball_actions[i]->layers_len; j++) {
+            if (curr_layer == config->ball_actions[i]->layers[j]) {
+                return BALL_ACTION;
+            }
+        }
+    }
     return MOVE;
 }
 
@@ -606,6 +623,14 @@ static int pmw3610_report_data(const struct device *dev) {
         set_cpi_if_needed(dev, CONFIG_PMW3610_SNIPE_CPI);
         dividor = CONFIG_PMW3610_SNIPE_CPI_DIVIDOR;
         break;
+    case BALL_ACTION:
+        set_cpi_if_needed(dev, CONFIG_PMW3610_CPI);
+        if (input_mode_changed) {
+            data->ball_action_delta_x = 0;
+            data->ball_action_delta_y = 0;
+        }
+        dividor = 1;
+        break;
     default:
         return -ENOTSUP;
     }
@@ -617,11 +642,11 @@ static int pmw3610_report_data(const struct device *dev) {
 
 #if AUTOMOUSE_LAYER > 0
     if (input_mode == MOVE &&
-        (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER) &&
-        (abs(x) + abs(y) > CONFIG_PMW3610_MOVEMENT_THRESHOLD)
-) {
-    activate_automouse_layer();
-}
+            (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER) &&
+            (abs(x) + abs(y) > CONFIG_PMW3610_MOVEMENT_THRESHOLD)
+    ) {
+        activate_automouse_layer();
+    }
 #endif
 
     int err = motion_burst_read(dev, buf, sizeof(buf));
@@ -689,7 +714,7 @@ static int pmw3610_report_data(const struct device *dev) {
 #endif
 
     if (x != 0 || y != 0) {
-        if (input_mode != SCROLL) {
+        if (input_mode == MOVE || input_mode == SNIPE) {
 #if AUTOMOUSE_LAYER > 0
             // トラックボールの動きの大きさを計算
             int16_t movement_size = abs(x) + abs(y);
@@ -701,7 +726,7 @@ static int pmw3610_report_data(const struct device *dev) {
 #endif
             input_report_rel(dev, INPUT_REL_X, x, false, K_FOREVER);
             input_report_rel(dev, INPUT_REL_Y, y, true, K_FOREVER);
-        } else {
+        } else if (input_mode == SCROLL) {
             data->scroll_delta_x += x;
             data->scroll_delta_y += y;
             if (abs(data->scroll_delta_y) > CONFIG_PMW3610_SCROLL_TICK) {
@@ -716,6 +741,49 @@ static int pmw3610_report_data(const struct device *dev) {
                                  true, K_FOREVER);
                 data->scroll_delta_x = 0;
                 data->scroll_delta_y = 0;
+            }
+        } else if (input_mode == BALL_ACTION) {
+            data->ball_action_delta_x += x;
+            data->ball_action_delta_y += y;
+
+            const struct pixart_config *config = dev->config;
+
+            for (int i = 0; i < config->ball_actions_len; i++) {
+                const struct ball_action_cfg action_cfg = *config->ball_actions[i];
+                const uint8_t current_layer = zmk_keymap_highest_layer_active();
+
+                for (int j = 0; j < action_cfg.layers_len; j++) {
+                    if (current_layer == action_cfg.layers[j]) {
+                        LOG_DBG("invoking ball action [%d], layer=%d", i, current_layer);
+
+                        struct zmk_behavior_binding_event event = {
+                            .position = INT32_MAX,
+                            .timestamp = k_uptime_get(),
+        #if IS_ENABLED(CONFIG_ZMK_SPLIT)
+                            .source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
+        #endif
+
+                        };
+
+                        // determine which binding to invoke
+                        int idx = -1;
+                        if(abs(data->ball_action_delta_x) > CONFIG_PMW3610_BALL_ACTION_TICK) {
+                            idx = data->ball_action_delta_x > 0 ? 0 : 1;
+                        } else if(abs(data->ball_action_delta_y) > CONFIG_PMW3610_BALL_ACTION_TICK) {
+                            idx = data->ball_action_delta_y > 0 ? 3 : 2;
+                        }
+
+                        if(idx != -1) {
+                            zmk_behavior_queue_add(&event, action_cfg.bindings[idx], true, config->tap_ms);
+                            zmk_behavior_queue_add(&event, action_cfg.bindings[idx], false, config->wait_ms);
+
+                            data->ball_action_delta_x = 0;
+                            data->ball_action_delta_y = 0;
+                        }
+
+                        break;
+                    }
+                }
             }
         }
     }
@@ -821,10 +889,34 @@ static int pmw3610_init(const struct device *dev) {
     return err;
 }
 
+
+#define TRANSFORMED_BINDINGS(n)                                                                    \
+    { LISTIFY(DT_PROP_LEN(n, bindings), ZMK_KEYMAP_EXTRACT_BINDING, (, ), n) }
+
+#define BALL_ACTIONS_INST(n)                                                                       \
+    static struct zmk_behavior_binding                                                             \
+        ball_action_config_##n##_bindings[DT_PROP_LEN(n, bindings)] = TRANSFORMED_BINDINGS(n);     \
+                                                                                                   \
+    static struct ball_action_cfg ball_action_cfg_##n = {                                          \
+        .bindings_len = DT_PROP_LEN(n, bindings),                                                  \
+        .bindings = ball_action_config_##n##_bindings,                                             \
+        .layers = DT_PROP(n, layers),                                                              \
+        .layers_len = DT_PROP_LEN(n, layers),                                                      \
+    };
+
+
+DT_INST_FOREACH_CHILD(0, BALL_ACTIONS_INST)
+
+#define BALL_ACTIONS_ITEM(n) &ball_action_cfg_##n,
+#define BALL_ACTIONS_UTIL_ONE(n) 1 +
+
+#define BALL_ACTIONS_LEN (DT_INST_FOREACH_CHILD(0, BALL_ACTIONS_UTIL_ONE) 0)
+
 #define PMW3610_DEFINE(n)                                                                          \
     static struct pixart_data data##n;                                                             \
     static int32_t scroll_layers##n[] = DT_PROP(DT_DRV_INST(n), scroll_layers);                    \
     static int32_t snipe_layers##n[] = DT_PROP(DT_DRV_INST(n), snipe_layers);                      \
+    static struct ball_action_cfg *ball_actions[] = {DT_INST_FOREACH_CHILD(0, BALL_ACTIONS_ITEM)}; \
     static const struct pixart_config config##n = {                                                \
         .irq_gpio = GPIO_DT_SPEC_INST_GET(n, irq_gpios),                                           \
         .bus =                                                                                     \
@@ -843,6 +935,10 @@ static int pmw3610_init(const struct device *dev) {
         .scroll_layers_len = DT_PROP_LEN(DT_DRV_INST(n), scroll_layers),                           \
         .snipe_layers = snipe_layers##n,                                                           \
         .snipe_layers_len = DT_PROP_LEN(DT_DRV_INST(n), snipe_layers),                             \
+        .ball_actions = ball_actions,                                                              \
+        .ball_actions_len = BALL_ACTIONS_LEN,                                                      \
+        .tap_ms = DT_INST_PROP(n, tap_ms),                                                         \
+        .wait_ms = DT_INST_PROP(n, wait_ms),                                                       \
     };                                                                                             \
                                                                                                    \
     DEVICE_DT_INST_DEFINE(n, pmw3610_init, NULL, &data##n, &config##n, POST_KERNEL,                \

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -898,9 +898,9 @@ static int pmw3610_init(const struct device *dev) {
         .bindings = ball_action_config_##n##_bindings,                                             \
         .layers = DT_PROP(n, layers),                                                              \
         .layers_len = DT_PROP_LEN(n, layers),                                                      \
-        .tick = DT_PROP_OR(n, tick, CONFIG_PMW3610_BALL_ACTION_TICK),                         \
-        .wait_ms = DT_PROP_OR(n, wait_ms, CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS),                            \
-        .tap_ms = DT_PROP_OR(n, tap_ms, CONFIG_ZMK_MACRO_DEFAULT_TAP_MS),                               \
+        .tick = DT_PROP_OR(n, tick, CONFIG_PMW3610_BALL_ACTION_TICK),                              \
+        .wait_ms = DT_PROP_OR(n, wait_ms, 0),                                                      \
+        .tap_ms = DT_PROP_OR(n, tap_ms, 0),                                                        \
     };
 
 


### PR DESCRIPTION
## 概要
トラボの上下左右操作にキー入力(正確には、任意のbehavior)を割り当てる機能を追加しました。

## 機能の詳細
`trackball: trackball@0 { ... }`に、以下のようにレイヤーとbindingを4つ(右左上下に対応)設定します。
以下は上下左右に矢印キーを割り当てる例です。
```dts
 arrows {
    layers = <3>;
    bindings =
        <&kp RIGHT_ARROW>,
        <&kp LEFT_ARROW>,
        <&kp UP_ARROW>,
        <&kp DOWN_ARROW>;

    tick = <10>;
    wait-ms = <5>;
    tap-ms = <5>;
};
```
指定されたレイヤーでトラックボールを上下左右へ動かすと、割り当てられたbehaviorが実行されます。

### パラメータ
- `tick`
  - 元々ある`CONFIG_PMW3610_SCROLL_TICK`と似たようなもので、小さくするほど感度が高くなります。
  - 省略可能で、デフォルトは20です。
- `wait-ms`、`tap-ms`
  - [マクロのもの](https://zmk.dev/docs/keymaps/behaviors/macros#wait-time) と同じ概念です。
  - 省略可能で、デフォルトは0としています。
- `CONFIG_PMW3610_BALL_ACTION_TICK`
  - デフォルトの`tick`を設定します。roBa_R.confへ記述します。
  - 省略可能で、デフォルトは20です。

## 変更内容
- 機能の追加
  - `Kconfig`: 感度のデフォルト値の追加
  - `README.md`: 設定例に矢印キーを割り当てる例を追加
  - `dts/bindings/pixart,pmw3610.yml`: 設定を追加
  - `src/pixart.h`: 構造体等を追加
  - `src/pmw3610.c`: 設定読み込みと処理を追加
- その他の変更
  - `MOVEMENT_THRESHOLD`の実装において、`x`と`y`変数を初期化前に参照していると警告が出ていたので、0で初期化して修正

## 動作確認
[zmk-config-roBaの方のPR](https://github.com/kumamuk-git/zmk-config-roBa/pull/11) で確認をお願いします。