### PR TITLE
トラボスクロールの動作改善及びスクロール加速機能の追加

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -173,6 +173,20 @@ config PMW3610_BALL_ACTION_TICK
     help
         Ball action tick value. Higher values require more movement to trigger a ball action.
 
+config PMW3610_SCROLL_ACCELERATION
+    bool "Enable scroll acceleration"
+    default n
+    help
+      Enable acceleration for scrolling based on movement speed.
+
+config PMW3610_SCROLL_ACCELERATION_SENSITIVITY
+    int "Scroll acceleration sensitivity (1-10)"
+    default 3
+    range 1 10
+    depends on PMW3610_SCROLL_ACCELERATION
+    help
+      Scrolling acceleration sensitivity. Higher values make scrolling more responsive with stronger acceleration.
+
 module = PMW3610
 module-str = PMW3610
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -34,6 +34,10 @@ struct pixart_data {
     int16_t last_y;
 #endif
 
+#ifdef CONFIG_PMW3610_SCROLL_ACCELERATION
+    int64_t last_scroll_time;
+#endif
+
     // motion interrupt isr
     struct gpio_callback irq_gpio_cb;
     // the work structure holding the trigger job
@@ -50,6 +54,9 @@ struct pixart_data {
 
     // for pmw3610 smart algorithm
     bool sw_smart_flag;
+
+    // for scroll acceleration
+    int64_t last_remainder_time;
 };
 
 // ball action config data structure


### PR DESCRIPTION
突然のPR失礼します。

トラボスクロールを改善する機能を実装しまして、恐らく私と同じような不満を持たれている方もおられるのではと思い、共有させていただきます。

もしこのようなPRを受け付けていないということであれば、遠慮なくクローズ頂いて結構です。
ユーザーとして使いやすくなる改善点と思い共有させていただきました。

## 現状の問題点
まず現状のトラボスクロールの問題点です
- トラックボールを素早く動かした時に、思ったほどスクロールしない
- むしろゆっくり動かした方が多くスクロールできる場合がある

この問題の原因はドライバの仕様で、トラボの動きがしきい値を超えると1回のスクロールイベントのみ生成され、残りの動きは捨てられてしまうことにより発生します。

以下でこの問題を解決しつつ、トラボスクロールをより良くするため、加速機能も付けました。

## 改善点
1. **余りの動きを繰り越し**
   - しきい値を超えたあまりを次の処理に繰り越すように
   - 100ms経過で自動リセット
 
2. **複数スクロールの対応**
   - 一度の素早い動きで複数回のスクロールが発生するように
   - 最大イベント数は20としています

3. **スクロール加速機能**
   - トラックボールの動きの速さに応じてスクロール量を調整(シグモイド関数を用いた自然な加速感)
   - 速い動きで大きくスクロール、遅い動きで精密操作が可能に

## 設定方法
zmk-configのroBa_R.confの方で以下設定を追加するとスクロール加速が可能となります
以下を記述しない場合でも上記1と2の影響はあり、素早く動かした際の動作が改善します
```
CONFIG_PMW3610_SCROLL_ACCELERATION=y
# 1-10の範囲
CONFIG_PMW3610_SCROLL_ACCELERATION_SENSITIVITY=3
```

## テスト
実際に私が1週間ほど使用してみて、という形ではありますが以下確認できています
 - キー入力など基本機能への影響がない
 - ポインティング動作への影響がない
 - トラボの上下左右操作にキー入力を割り当てる機能(PR#3)への影響がない


以上、もしよければ検討いただけると嬉しいです。実際に使って試して頂けると違いが実感できると思います。何か質問があればコメント頂ければと思います。